### PR TITLE
chore: Configure the otelcol-contrib

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -18,7 +18,7 @@ x-common-env: &common-env
   OIDC_TRUSTED_AUDIENCES:
   OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST: ".*"
   OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_RESPONSE: ".*"
-  OTEL_EXPORTER_OTLP_ENDPOINT: http://jaeger:4317
+  OTEL_EXPORTER_OTLP_ENDPOINT: http://otel-collector:4317
 
 services:
   database:
@@ -55,9 +55,17 @@ services:
       - jaeger
     ports:
       - "4317:4317"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 256M
+        reservations:
+          cpus: '0.05'
+          memory: 128M
 
   jaeger:
-    image: jaegertracing/jaeger:2.2.0
+    image: jaegertracing/jaeger:2.8.0
     ports:
       # ui
       - "16686:16686"
@@ -77,7 +85,7 @@ services:
       DJANGO_SETTINGS_MODULE: main.settings
     depends_on:
       <<: *common-depends-on
-      jaeger:
+      otel-collector:
         condition: service_started
     volumes:
       - .:/app
@@ -97,7 +105,7 @@ services:
       DJANGO_SUPERUSER_EMAIL: "admin@amsterdam.nl"
     depends_on:
       <<: *common-depends-on
-      jaeger:
+      otel-collector:
         condition: service_started
     volumes:
       - .:/app

--- a/otel-collector/Dockerfile
+++ b/otel-collector/Dockerfile
@@ -1,3 +1,3 @@
-FROM otel/opentelemetry-collector-contrib:0.119.0
+FROM otel/opentelemetry-collector-contrib:0.129.1
 
 COPY config.local.yaml /etc/otelcol-contrib/config.yaml

--- a/otel-collector/config.local.yaml
+++ b/otel-collector/config.local.yaml
@@ -13,21 +13,32 @@ exporters:
       insecure: true
 
 processors:
+  memory_limiter:
+    check_interval: 1s
+    limit_mib: 180
+    spike_limit_mib: 30
+
   batch:
+    timeout: 1s
+    send_batch_size: 256
+    send_batch_max_size: 512
+
+  probabilistic_sampler:
+    sampling_percentage: 100
 
 service:
   telemetry:
     logs:
-      level: DEBUG
+      level: INFO
   pipelines:
     logs:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, batch]
       exporters:
         - debug
     traces:
       receivers: [otlp]
-      processors: [batch]
+      processors: [memory_limiter, probabilistic_sampler, batch]
       exporters:
         - debug
         - otlp/jaeger


### PR DESCRIPTION
Configure the locally used otelcol-contrib to mimic the OAP environments better.

Also added configuration changes in the collector before applying them to the OAP environments.